### PR TITLE
opengrep: apply agent fixes

### DIFF
--- a/general.ts
+++ b/general.ts
@@ -1,5 +1,35 @@
 import { capitalizeFirst, capitalizeFirstPerWord, caseType } from "./case-types-parser";
 
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * Safely access obj[key], throwing on prototype-pollution keys.
+ * Use when key comes from user input or dynamic paths (e.g. dot-notation split).
+ * @param obj - Object to read from
+ * @param key - Property key (string or number)
+ * @returns The value at obj[key]
+ */
+export function safeAccess(obj: any, key: string | number): any {
+    if (typeof key === 'string' && UNSAFE_KEYS.has(key)) {
+        throw new Error(`Unsafe key rejected: ${key}`);
+    }
+    return obj[key];
+}
+
+/**
+ * Safely set obj[key] = value, throwing on prototype-pollution keys.
+ * Use when key comes from user input or dynamic paths.
+ * @param obj - Object to write to
+ * @param key - Property key (string or number)
+ * @param value - Value to set
+ */
+export function safeSet(obj: any, key: string | number, value: any): void {
+    if (typeof key === 'string' && UNSAFE_KEYS.has(key)) {
+        throw new Error(`Unsafe key rejected: ${key}`);
+    }
+    obj[key] = value;
+}
+
 export function jsonCopy(src: any): any {
     return JSON.parse(JSON.stringify(src));
 }
@@ -36,7 +66,7 @@ function getKeyValue(obj: any, key: string) {
     const keys = key.split('.');
     let target = obj;
     keys.forEach((key: string) => {
-        target = target[key];
+        target = safeAccess(target, key);
     });
     return target;
 }


### PR DESCRIPTION
Automated opengrep resolution: static-analysis findings fixed by Cursor Agent. Please review the changes and verify correctness.

### Included changes
- `general.ts:39` — **javascript.lang.security.audit.prototype-pollution.prototype-pollution-loop.prototype-pollution-loop** (WARNING)

**Main PR:** https://github.com/code-kern-ai/refinery-gateway/pull/384

**All related PRs:**
- [sub] **cognition-gateway**: https://github.com/code-kern-ai/cognition-gateway/pull/307
- [sub] **cognition-ui**: https://github.com/code-kern-ai/cognition-ui/pull/203
- [main] **refinery-gateway**: https://github.com/code-kern-ai/refinery-gateway/pull/384
- [sub] **refinery-submodule-model**: https://github.com/code-kern-ai/refinery-submodule-model/pull/224
- [sub] **refinery-ui**: https://github.com/code-kern-ai/refinery-ui/pull/93
- [sub] **submodule-javascript-functions**: https://github.com/code-kern-ai/submodule-javascript-functions/pull/31
- [sub] **submodule-react-components**: https://github.com/code-kern-ai/submodule-react-components/pull/75